### PR TITLE
HTBHF-682 convert incoming request body to match expected shape

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/controller/HMRCEligibilityController.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/controller/HMRCEligibilityController.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.dhsc.htbhf.hmrc.converter.EligibilityRequestToHMRCEligibilityRequest;
 import uk.gov.dhsc.htbhf.hmrc.model.EligibilityRequest;
 import uk.gov.dhsc.htbhf.hmrc.model.EligibilityResponse;
+import uk.gov.dhsc.htbhf.hmrc.model.HMRCEligibilityRequest;
 import uk.gov.dhsc.htbhf.hmrc.service.EligibilityService;
 
 import javax.validation.Valid;
@@ -21,6 +23,7 @@ import javax.validation.Valid;
 public class HMRCEligibilityController {
 
     private final EligibilityService eligibilityService;
+    private final EligibilityRequestToHMRCEligibilityRequest converter;
 
     @PostMapping
     @ApiOperation("Retrieve the eligibility of a person for Healthy Start based on HMRC's opinion of their income "
@@ -32,6 +35,9 @@ public class HMRCEligibilityController {
                                            @ApiParam("The eligibility request for HMRC for Healthy Start")
                                            EligibilityRequest eligibilityRequest) {
         log.debug("Received HMRC eligibility request");
-        return eligibilityService.checkEligibility(eligibilityRequest);
+
+        HMRCEligibilityRequest request = converter.convert(eligibilityRequest);
+
+        return eligibilityService.checkEligibility(request);
     }
 }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/converter/EligibilityRequestToHMRCEligibilityRequest.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/converter/EligibilityRequestToHMRCEligibilityRequest.java
@@ -1,0 +1,34 @@
+package uk.gov.dhsc.htbhf.hmrc.converter;
+
+import lombok.AllArgsConstructor;
+
+import org.springframework.stereotype.Component;
+import uk.gov.dhsc.htbhf.hmrc.model.EligibilityRequest;
+import uk.gov.dhsc.htbhf.hmrc.model.HMRCEligibilityRequest;
+import uk.gov.dhsc.htbhf.hmrc.model.HMRCPersonDTO;
+import uk.gov.dhsc.htbhf.hmrc.model.PersonDTO;
+
+@Component
+@AllArgsConstructor
+public class EligibilityRequestToHMRCEligibilityRequest {
+
+    public HMRCEligibilityRequest convert(EligibilityRequest eligibilityRequest) {
+        return HMRCEligibilityRequest.builder()
+                .person(convertPerson(eligibilityRequest.getPerson()))
+                .eligibleStartDate(eligibilityRequest.getEligibleStartDate())
+                .eligibleEndDate(eligibilityRequest.getEligibleEndDate())
+                .ctcAnnualIncomeThreshold(eligibilityRequest.getCtcAnnualIncomeThreshold())
+                .build();
+    }
+
+    public HMRCPersonDTO convertPerson(PersonDTO person) {
+        return HMRCPersonDTO.builder()
+                .address(person.getAddress())
+                .dateOfBirth(person.getDateOfBirth())
+                .forename(person.getFirstName())
+                .surname(person.getLastName())
+                .nino(person.getNino())
+                .build();
+    }
+}
+

--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/model/HMRCEligibilityRequest.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/model/HMRCEligibilityRequest.java
@@ -1,0 +1,29 @@
+package uk.gov.dhsc.htbhf.hmrc.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+@AllArgsConstructor(onConstructor_ = {@JsonCreator})
+public class HMRCEligibilityRequest {
+
+    @JsonProperty("person")
+    private HMRCPersonDTO person;
+
+    @JsonProperty("ctcAnnualIncomeThreshold")
+    private final BigDecimal ctcAnnualIncomeThreshold;
+
+    @JsonProperty("eligibleStartDate")
+    private final LocalDate eligibleStartDate;
+
+    @JsonProperty("eligibleEndDate")
+    private final LocalDate eligibleEndDate;
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/model/HMRCPersonDTO.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/model/HMRCPersonDTO.java
@@ -1,0 +1,31 @@
+package uk.gov.dhsc.htbhf.hmrc.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@AllArgsConstructor(onConstructor_ = {@JsonCreator})
+public class HMRCPersonDTO {
+
+    @JsonProperty("forename")
+    private final String forename;
+
+    @JsonProperty("surname")
+    private final String surname;
+
+    @JsonProperty("nino")
+    private final String nino;
+
+    @JsonProperty("dateOfBirth")
+    private final LocalDate dateOfBirth;
+
+    @JsonProperty("address")
+    private final AddressDTO address;
+}

--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/model/PersonDTO.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/model/PersonDTO.java
@@ -21,14 +21,14 @@ import javax.validation.constraints.Pattern;
 public class PersonDTO {
 
     @NotNull
-    @JsonProperty("forename")
-    @ApiModelProperty(notes = "The person's forename", example = "Lisa")
-    private final String forename;
+    @JsonProperty("firstName")
+    @ApiModelProperty(notes = "The person's first name", example = "Lisa")
+    private final String firstName;
 
     @NotNull
-    @JsonProperty("surname")
-    @ApiModelProperty(notes = "The person's surname", example = "Simpson")
-    private final String surname;
+    @JsonProperty("lastName")
+    @ApiModelProperty(notes = "The person's last name", example = "Simpson")
+    private final String lastName;
 
     @NotNull
     @Pattern(regexp = "[a-zA-Z]{2}\\d{6}[a-dA-D]")

--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/service/EligibilityService.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/service/EligibilityService.java
@@ -5,8 +5,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.dhsc.htbhf.hmrc.entity.Household;
-import uk.gov.dhsc.htbhf.hmrc.model.EligibilityRequest;
 import uk.gov.dhsc.htbhf.hmrc.model.EligibilityResponse;
+import uk.gov.dhsc.htbhf.hmrc.model.HMRCEligibilityRequest;
 import uk.gov.dhsc.htbhf.hmrc.repository.HouseholdRepository;
 
 import java.util.Optional;
@@ -34,7 +34,7 @@ public class EligibilityService {
         this.restTemplate = restTemplate;
     }
 
-    public EligibilityResponse checkEligibility(EligibilityRequest eligibilityRequest) {
+    public EligibilityResponse checkEligibility(HMRCEligibilityRequest eligibilityRequest) {
         Optional<Household> household = repository.findHouseholdByAdultWithNino(eligibilityRequest.getPerson().getNino());
         if (household.isPresent()) {
             return getEligibilityResponse(eligibilityRequest, household.get());
@@ -43,13 +43,13 @@ public class EligibilityService {
         return getResponseFromHMRC(eligibilityRequest);
     }
 
-    private EligibilityResponse getEligibilityResponse(EligibilityRequest eligibilityRequest, Household household) {
+    private EligibilityResponse getEligibilityResponse(HMRCEligibilityRequest eligibilityRequest, Household household) {
         return householdVerifier.detailsMatch(household, eligibilityRequest.getPerson())
                 ? createEligibilityResponse(household)
                 : EligibilityResponse.builder().eligibilityStatus(NOMATCH).build();
     }
 
-    private EligibilityResponse getResponseFromHMRC(EligibilityRequest eligibilityRequest) {
+    private EligibilityResponse getResponseFromHMRC(HMRCEligibilityRequest eligibilityRequest) {
         ResponseEntity<EligibilityResponse> response = restTemplate.postForEntity(uri, eligibilityRequest, EligibilityResponse.class);
         return response.getBody();
     }

--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/service/HouseholdVerifier.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/service/HouseholdVerifier.java
@@ -4,17 +4,17 @@ import org.flywaydb.core.internal.util.StringUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.dhsc.htbhf.hmrc.entity.Adult;
 import uk.gov.dhsc.htbhf.hmrc.entity.Household;
-import uk.gov.dhsc.htbhf.hmrc.model.PersonDTO;
+import uk.gov.dhsc.htbhf.hmrc.model.HMRCPersonDTO;
 
 @Service
 public class HouseholdVerifier {
 
-    public Boolean detailsMatch(Household household, PersonDTO person) {
+    public Boolean detailsMatch(Household household, HMRCPersonDTO person) {
         return household.getAdults().stream()
                 .anyMatch(adult -> adultMatchesPerson(adult, person));
     }
 
-    private boolean adultMatchesPerson(Adult adult, PersonDTO person) {
+    private boolean adultMatchesPerson(Adult adult, HMRCPersonDTO person) {
         return areEqual(adult.getSurname(), person.getSurname())
                 && firstSixCharacterMatch(person.getAddress().getAddressLine1(), adult.getAddressLine1())
                 && areEqualIgnoringWhitespace(adult.getPostcode(), person.getAddress().getPostcode());

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/controller/HMRCEligibilityControllerIntegrationTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/controller/HMRCEligibilityControllerIntegrationTest.java
@@ -9,8 +9,10 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.dhsc.htbhf.errorhandler.ErrorResponse;
+import uk.gov.dhsc.htbhf.hmrc.converter.EligibilityRequestToHMRCEligibilityRequest;
 import uk.gov.dhsc.htbhf.hmrc.model.EligibilityRequest;
 import uk.gov.dhsc.htbhf.hmrc.model.EligibilityResponse;
+import uk.gov.dhsc.htbhf.hmrc.model.HMRCEligibilityRequest;
 import uk.gov.dhsc.htbhf.hmrc.model.PersonDTO;
 import uk.gov.dhsc.htbhf.hmrc.service.EligibilityService;
 
@@ -25,6 +27,7 @@ import static uk.gov.dhsc.htbhf.assertions.IntegrationTestAssertions.assertValid
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.EligibilityRequestTestFactory.anEligibilityRequest;
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.EligibilityRequestTestFactory.anEligibilityRequestWithPerson;
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.EligibilityResponseTestFactory.anEligibilityResponse;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HMRCEligibilityRequestTestDataFactory.aValidHMRCEligibilityRequest;
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.PersonDTOTestFactory.aPersonWithNino;
 
 @ExtendWith(SpringExtension.class)
@@ -39,16 +42,22 @@ class HMRCEligibilityControllerIntegrationTest {
     @MockBean
     private EligibilityService eligibilityService;
 
+    @MockBean
+    private EligibilityRequestToHMRCEligibilityRequest converter;
+
     @Test
     void shouldReturnEligibilityResponse() {
         EligibilityRequest eligibilityRequest = anEligibilityRequest();
+        HMRCEligibilityRequest hmrcEligibilityRequest = aValidHMRCEligibilityRequest();
+        given(converter.convert(any())).willReturn(hmrcEligibilityRequest);
         given(eligibilityService.checkEligibility(any())).willReturn(anEligibilityResponse());
 
         ResponseEntity<EligibilityResponse> response = restTemplate.postForEntity(ENDPOINT, eligibilityRequest, EligibilityResponse.class);
 
         assertThat(response.getStatusCode()).isEqualTo(OK);
         assertThat(response.getBody()).isEqualTo(anEligibilityResponse());
-        verify(eligibilityService).checkEligibility(eligibilityRequest);
+        verify(converter).convert(eligibilityRequest);
+        verify(eligibilityService).checkEligibility(hmrcEligibilityRequest);
     }
 
     @Test

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/converter/EligibilityRequestToHMRCEligibilityRequestTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/converter/EligibilityRequestToHMRCEligibilityRequestTest.java
@@ -1,0 +1,28 @@
+package uk.gov.dhsc.htbhf.hmrc.converter;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.dhsc.htbhf.hmrc.model.EligibilityRequest;
+import uk.gov.dhsc.htbhf.hmrc.model.HMRCEligibilityRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.EligibilityRequestTestFactory.anEligibilityRequest;
+
+public class EligibilityRequestToHMRCEligibilityRequestTest {
+    private EligibilityRequestToHMRCEligibilityRequest converter = new EligibilityRequestToHMRCEligibilityRequest();
+
+    @Test
+    void shouldConvertRequest() {
+        EligibilityRequest request = anEligibilityRequest();
+
+        HMRCEligibilityRequest result = converter.convert(request);
+
+        assertThat(result.getEligibleStartDate()).isEqualTo(request.getEligibleStartDate());
+        assertThat(result.getEligibleEndDate()).isEqualTo(request.getEligibleEndDate());
+        assertThat(result.getCtcAnnualIncomeThreshold()).isEqualTo(request.getCtcAnnualIncomeThreshold());
+        assertThat(result.getPerson().getAddress()).isEqualTo(request.getPerson().getAddress());
+        assertThat(result.getPerson().getDateOfBirth()).isEqualTo(request.getPerson().getDateOfBirth());
+        assertThat(result.getPerson().getForename()).isEqualTo(request.getPerson().getFirstName());
+        assertThat(result.getPerson().getSurname()).isEqualTo(request.getPerson().getLastName());
+        assertThat(result.getPerson().getNino()).isEqualTo(request.getPerson().getNino());
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/factory/PersonTestFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/factory/PersonTestFactory.java
@@ -54,8 +54,8 @@ public class PersonTestFactory {
                 .dateOfBirth(DOB)
                 .nino(NINO)
                 .address(aValidAddress())
-                .forename(FORENAME)
-                .surname(SURNAME);
+                .firstName(FORENAME)
+                .lastName(SURNAME);
     }
 
     private static AddressDTO aValidAddress() {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/model/PersonDTOTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/model/PersonDTOTest.java
@@ -28,21 +28,21 @@ class PersonDTOTest extends AbstractValidationTest {
     @Test
     void shouldFailValidationWithNoForename() {
         //Given
-        PersonDTO person = aPersonWithForename(null);
+        PersonDTO person = aPersonWithFirstName(null);
         //When
         Set<ConstraintViolation<PersonDTO>> violations = validator.validate(person);
         //Then
-        assertThat(violations).hasSingleConstraintViolation("must not be null", "forename");
+        assertThat(violations).hasSingleConstraintViolation("must not be null", "firstName");
     }
 
     @Test
     void shouldFailValidationWithNoSurname() {
         //Given
-        PersonDTO person = aPersonWithSurname(null);
+        PersonDTO person = aPersonWithLastName(null);
         //When
         Set<ConstraintViolation<PersonDTO>> violations = validator.validate(person);
         //Then
-        assertThat(violations).hasSingleConstraintViolation("must not be null", "surname");
+        assertThat(violations).hasSingleConstraintViolation("must not be null", "lastName");
     }
 
     @Test

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/service/EligibilityServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/service/EligibilityServiceTest.java
@@ -10,8 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.dhsc.htbhf.hmrc.entity.Household;
-import uk.gov.dhsc.htbhf.hmrc.model.EligibilityRequest;
 import uk.gov.dhsc.htbhf.hmrc.model.EligibilityResponse;
+import uk.gov.dhsc.htbhf.hmrc.model.HMRCEligibilityRequest;
 import uk.gov.dhsc.htbhf.hmrc.repository.HouseholdRepository;
 
 import java.util.Optional;
@@ -24,8 +24,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.springframework.http.HttpStatus.OK;
 import static uk.gov.dhsc.htbhf.hmrc.entity.HouseholdFactory.aHousehold;
-import static uk.gov.dhsc.htbhf.hmrc.testhelper.EligibilityRequestTestFactory.anEligibilityRequest;
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.EligibilityResponseTestFactory.anEligibilityResponse;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HMRCEligibilityRequestTestDataFactory.aValidHMRCEligibilityRequest;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -50,7 +50,7 @@ class EligibilityServiceTest {
 
     @Test
     void shouldReturnResponseFromDatabaseIfFound() {
-        EligibilityRequest eligibilityRequest = anEligibilityRequest();
+        HMRCEligibilityRequest eligibilityRequest = aValidHMRCEligibilityRequest();
         Household household = aHousehold();
         given(repository.findHouseholdByAdultWithNino(anyString())).willReturn(Optional.of(household));
         given(householdVerifier.detailsMatch(any(Household.class), any())).willReturn(true);
@@ -68,7 +68,7 @@ class EligibilityServiceTest {
 
     @Test
     void shouldCallHMRCService() {
-        EligibilityRequest eligibilityRequest = anEligibilityRequest();
+        HMRCEligibilityRequest eligibilityRequest = aValidHMRCEligibilityRequest();
         given(repository.findHouseholdByAdultWithNino(anyString())).willReturn(Optional.empty());
         given(restTemplate.postForEntity(anyString(), any(), any()))
                 .willReturn(new ResponseEntity<>(anEligibilityResponse(), OK));

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/service/HouseholdVerifierTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/service/HouseholdVerifierTest.java
@@ -6,8 +6,11 @@ import uk.gov.dhsc.htbhf.hmrc.entity.Household;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static uk.gov.dhsc.htbhf.hmrc.entity.HouseholdFactory.aHouseholdWithNoAdultsOrChildren;
-import static uk.gov.dhsc.htbhf.hmrc.factory.PersonTestFactory.aPerson;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HMRCPersonDTOTestDataFactory.aValidHMRCPerson;
 
+/**
+ * To match a valid address use address data defined in AddressDTOTestDataFactory.
+ */
 public class HouseholdVerifierTest {
 
     private final HouseholdVerifier householdVerifier = new HouseholdVerifier();
@@ -17,12 +20,12 @@ public class HouseholdVerifierTest {
         Adult adult = Adult.builder()
                 .firstForename("Lisa")
                 .surname("Simpson")
-                .addressLine1("742 Evergreen Terrace")
+                .addressLine1("Flat b")
                 .postcode("AA11AA")
                 .build();
         Household household = aHouseholdWithNoAdultsOrChildren().build().addAdult(adult);
 
-        Boolean response = householdVerifier.detailsMatch(household, aPerson());
+        Boolean response = householdVerifier.detailsMatch(household, aValidHMRCPerson());
 
         assertThat(response).isTrue();
     }
@@ -32,12 +35,12 @@ public class HouseholdVerifierTest {
         Adult adult = Adult.builder()
                 .firstForename("Lisa")
                 .surname("Smith")
-                .addressLine1("742 Evergreen Terrace")
+                .addressLine1("Flat b")
                 .postcode("AA11AA")
                 .build();
         Household household = aHouseholdWithNoAdultsOrChildren().build().addAdult(adult);
 
-        Boolean response = householdVerifier.detailsMatch(household, aPerson());
+        Boolean response = householdVerifier.detailsMatch(household, aValidHMRCPerson());
 
         assertThat(response).isFalse();
     }
@@ -47,12 +50,12 @@ public class HouseholdVerifierTest {
         Adult adult = Adult.builder()
                 .firstForename("Lisa")
                 .surname("Simpson")
-                .addressLine1("Fake Street")
+                .addressLine1("Fake apartment")
                 .postcode("AA11AA")
                 .build();
         Household household = aHouseholdWithNoAdultsOrChildren().build().addAdult(adult);
 
-        Boolean response = householdVerifier.detailsMatch(household, aPerson());
+        Boolean response = householdVerifier.detailsMatch(household, aValidHMRCPerson());
 
         assertThat(response).isFalse();
     }
@@ -67,7 +70,7 @@ public class HouseholdVerifierTest {
                 .build();
         Household household = aHouseholdWithNoAdultsOrChildren().build().addAdult(adult);
 
-        Boolean response = householdVerifier.detailsMatch(household, aPerson());
+        Boolean response = householdVerifier.detailsMatch(household, aValidHMRCPerson());
 
         assertThat(response).isFalse();
     }
@@ -77,12 +80,12 @@ public class HouseholdVerifierTest {
         Adult adult = Adult.builder()
                 .firstForename("Lisa")
                 .surname("Simpson")
-                .addressLine1("742 Ev_DIFFERENT")
+                .addressLine1("Flat b_DIFFERENT")
                 .postcode("AA11AA")
                 .build();
         Household household = aHouseholdWithNoAdultsOrChildren().build().addAdult(adult);
 
-        Boolean response = householdVerifier.detailsMatch(household, aPerson());
+        Boolean response = householdVerifier.detailsMatch(household, aValidHMRCPerson());
 
         assertThat(response).isTrue();
     }
@@ -92,12 +95,12 @@ public class HouseholdVerifierTest {
         Adult adult = Adult.builder()
                 .firstForename("Lisa")
                 .surname("Simpson")
-                .addressLine1("742 ev_DIFFERENT")
+                .addressLine1("FLAT B_DIFFERENT")
                 .postcode("AA11AA")
                 .build();
         Household household = aHouseholdWithNoAdultsOrChildren().build().addAdult(adult);
 
-        Boolean response = householdVerifier.detailsMatch(household, aPerson());
+        Boolean response = householdVerifier.detailsMatch(household, aValidHMRCPerson());
 
         assertThat(response).isTrue();
     }
@@ -107,12 +110,12 @@ public class HouseholdVerifierTest {
         Adult adult = Adult.builder()
                 .firstForename("Lisa")
                 .surname("Simpson")
-                .addressLine1("742")
+                .addressLine1("Flat")
                 .postcode("AA11AA")
                 .build();
         Household household = aHouseholdWithNoAdultsOrChildren().build().addAdult(adult);
 
-        Boolean response = householdVerifier.detailsMatch(household, aPerson());
+        Boolean response = householdVerifier.detailsMatch(household, aValidHMRCPerson());
 
         assertThat(response).isFalse();
     }
@@ -122,12 +125,12 @@ public class HouseholdVerifierTest {
         Adult adult = Adult.builder()
                 .firstForename("Lisa")
                 .surname("Simpson")
-                .addressLine1("742 Evergreen Terrace")
+                .addressLine1("Flat b")
                 .postcode("AA1 1AA")
                 .build();
         Household household = aHouseholdWithNoAdultsOrChildren().build().addAdult(adult);
 
-        Boolean response = householdVerifier.detailsMatch(household, aPerson());
+        Boolean response = householdVerifier.detailsMatch(household, aValidHMRCPerson());
 
         assertThat(response).isTrue();
     }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/testhelper/HMRCEligibilityRequestTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/testhelper/HMRCEligibilityRequestTestDataFactory.java
@@ -1,0 +1,26 @@
+package uk.gov.dhsc.htbhf.hmrc.testhelper;
+
+import uk.gov.dhsc.htbhf.hmrc.model.HMRCEligibilityRequest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HMRCPersonDTOTestDataFactory.aValidHMRCPerson;
+
+public class HMRCEligibilityRequestTestDataFactory {
+    private static final BigDecimal CTC_ANNUAL_INCOME_THRESHOLD = new BigDecimal(408);
+    private static final LocalDate ELIGIBLE_START_DATE = LocalDate.parse("2019-01-01");
+    private static final LocalDate ELIGIBLE_END_DATE = LocalDate.parse("2019-02-01");
+
+    public static HMRCEligibilityRequest aValidHMRCEligibilityRequest() {
+        return aValidEligibilityRequestBuilder().build();
+    }
+
+    private static HMRCEligibilityRequest.HMRCEligibilityRequestBuilder aValidEligibilityRequestBuilder() {
+        return HMRCEligibilityRequest.builder()
+                .person(aValidHMRCPerson())
+                .ctcAnnualIncomeThreshold(CTC_ANNUAL_INCOME_THRESHOLD)
+                .eligibleStartDate(ELIGIBLE_START_DATE)
+                .eligibleEndDate(ELIGIBLE_END_DATE);
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/testhelper/HMRCPersonDTOTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/testhelper/HMRCPersonDTOTestDataFactory.java
@@ -1,0 +1,27 @@
+package uk.gov.dhsc.htbhf.hmrc.testhelper;
+
+import uk.gov.dhsc.htbhf.hmrc.model.HMRCPersonDTO;
+
+import java.time.LocalDate;
+
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.AddressDTOTestDataFactory.aValidAddress;
+
+public class HMRCPersonDTOTestDataFactory {
+    private static final LocalDate DOB = LocalDate.parse("1985-12-31");
+    private static final String NINO = "EB123456C";
+    private static final String FORENAME = "Lisa";
+    private static final String SURNAME = "Simpson";
+
+    public static HMRCPersonDTO aValidHMRCPerson() {
+        return buildDefaultHMRCPerson().build();
+    }
+
+    private static HMRCPersonDTO.HMRCPersonDTOBuilder buildDefaultHMRCPerson() {
+        return HMRCPersonDTO.builder()
+                .dateOfBirth(DOB)
+                .nino(NINO)
+                .address(aValidAddress())
+                .forename(FORENAME)
+                .surname(SURNAME);
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/testhelper/PersonDTOTestFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/testhelper/PersonDTOTestFactory.java
@@ -18,12 +18,12 @@ public class PersonDTOTestFactory {
         return buildDefaultPerson().nino("AE000000C").build();
     }
 
-    public static PersonDTO aPersonWithForename(String forename) {
-        return buildDefaultPerson().forename(forename).build();
+    public static PersonDTO aPersonWithFirstName(String forename) {
+        return buildDefaultPerson().firstName(forename).build();
     }
 
-    public static PersonDTO aPersonWithSurname(String surname) {
-        return buildDefaultPerson().surname(surname).build();
+    public static PersonDTO aPersonWithLastName(String surname) {
+        return buildDefaultPerson().lastName(surname).build();
     }
 
     public static PersonDTO aPersonWithNino(String nino) {
@@ -43,8 +43,8 @@ public class PersonDTOTestFactory {
                 .dateOfBirth(DOB)
                 .nino(NINO)
                 .address(aValidAddress())
-                .forename(FORENAME)
-                .surname(SURNAME);
+                .firstName(FORENAME)
+                .lastName(SURNAME);
     }
 
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -11,7 +11,7 @@ info:
   license:
     name: "MIT"
     url: "https://opensource.org/licenses/MIT"
-host: "localhost:45895"
+host: "localhost:60376"
 basePath: "/"
 tags:
 - name: "hmrc-eligibility-controller"
@@ -134,18 +134,18 @@ definitions:
         format: "date"
         example: "1985-12-30"
         description: "The date of birth, in the format YYYY-MM-DD"
-      forename:
+      firstName:
         type: "string"
         example: "Lisa"
-        description: "The person's forename"
+        description: "The person's first name"
+      lastName:
+        type: "string"
+        example: "Simpson"
+        description: "The person's last name"
       nino:
         type: "string"
         example: "QQ123456C"
         description: "National Insurance number"
         pattern: "[a-zA-Z]{2}\\d{6}[a-dA-D]"
-      surname:
-        type: "string"
-        example: "Simpson"
-        description: "The person's surname"
     title: "PersonDTO"
     description: "The person who we are checking eligibility for"


### PR DESCRIPTION
- Add HMRCEligibilityRequest and HMRCPersonDTO models
- Convert incoming request in controller
- Update all tests to expect correct person types
- Update household verifier tests to match test data defined in address DTO test data factory

Regarding the last point, there are duplicate test data factory classes defined in different directories which I think is causing confusion. I will tidy these up in a subsequent PR.