### PR TITLE
HTBHF-951 Fix missing eligibility status on eligibility response

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/ApiDocumentation.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/ApiDocumentation.java
@@ -27,6 +27,7 @@ public class ApiDocumentation {
     @Bean
     public Docket apiDocket() {
         return new Docket(DocumentationType.SWAGGER_2)
+                .host("N/A")
                 .select()
                 .apis(RequestHandlerSelectors.basePackage(this.getClass().getPackageName()))
                 .paths(PathSelectors.any())

--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/factory/EligibilityResponseFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/factory/EligibilityResponseFactory.java
@@ -10,9 +10,9 @@ import java.util.Set;
 
 public class EligibilityResponseFactory {
 
-    public static EligibilityResponse createEligibleResponse(Household household) {
+    public static EligibilityResponse createEligibilityResponse(Household household, EligibilityStatus status) {
         return EligibilityResponse.builder()
-                .eligibilityStatus(EligibilityStatus.ELIGIBLE)
+                .eligibilityStatus(status)
                 .numberOfChildrenUnderOne(getNumberOfChildrenUnderOne(household.getChildren()))
                 .numberOfChildrenUnderFour(getNumberOfChildrenUnderFour(household.getChildren()))
                 .householdIdentifier(household.getHouseholdIdentifier())

--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/factory/EligibilityResponseFactory.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/factory/EligibilityResponseFactory.java
@@ -3,14 +3,16 @@ package uk.gov.dhsc.htbhf.hmrc.factory;
 import uk.gov.dhsc.htbhf.hmrc.entity.Child;
 import uk.gov.dhsc.htbhf.hmrc.entity.Household;
 import uk.gov.dhsc.htbhf.hmrc.model.EligibilityResponse;
+import uk.gov.dhsc.htbhf.hmrc.model.EligibilityStatus;
 
 import java.time.LocalDate;
 import java.util.Set;
 
 public class EligibilityResponseFactory {
 
-    public static EligibilityResponse createEligibilityResponse(Household household) {
+    public static EligibilityResponse createEligibleResponse(Household household) {
         return EligibilityResponse.builder()
+                .eligibilityStatus(EligibilityStatus.ELIGIBLE)
                 .numberOfChildrenUnderOne(getNumberOfChildrenUnderOne(household.getChildren()))
                 .numberOfChildrenUnderFour(getNumberOfChildrenUnderFour(household.getChildren()))
                 .householdIdentifier(household.getHouseholdIdentifier())

--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/service/EligibilityService.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/service/EligibilityService.java
@@ -12,9 +12,9 @@ import uk.gov.dhsc.htbhf.hmrc.repository.HouseholdRepository;
 
 import java.util.Optional;
 
-import static uk.gov.dhsc.htbhf.hmrc.factory.EligibilityResponseFactory.createEligibleResponse;
+import static uk.gov.dhsc.htbhf.hmrc.factory.EligibilityResponseFactory.createEligibilityResponse;
+import static uk.gov.dhsc.htbhf.hmrc.model.EligibilityStatus.ELIGIBLE;
 import static uk.gov.dhsc.htbhf.hmrc.model.EligibilityStatus.NOMATCH;
-
 
 @Service
 @Slf4j
@@ -49,7 +49,7 @@ public class EligibilityService {
 
     private EligibilityResponse getEligibilityResponse(HMRCEligibilityRequest eligibilityRequest, Household household) {
         return householdVerifier.detailsMatch(household, eligibilityRequest.getPerson())
-                ? createEligibleResponse(household)
+                ? createEligibilityResponse(household, ELIGIBLE)
                 : EligibilityResponse.builder().eligibilityStatus(NOMATCH).build();
     }
 

--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/service/EligibilityService.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/service/EligibilityService.java
@@ -12,7 +12,7 @@ import uk.gov.dhsc.htbhf.hmrc.repository.HouseholdRepository;
 
 import java.util.Optional;
 
-import static uk.gov.dhsc.htbhf.hmrc.factory.EligibilityResponseFactory.createEligibilityResponse;
+import static uk.gov.dhsc.htbhf.hmrc.factory.EligibilityResponseFactory.createEligibleResponse;
 import static uk.gov.dhsc.htbhf.hmrc.model.EligibilityStatus.NOMATCH;
 
 
@@ -49,7 +49,7 @@ public class EligibilityService {
 
     private EligibilityResponse getEligibilityResponse(HMRCEligibilityRequest eligibilityRequest, Household household) {
         return householdVerifier.detailsMatch(household, eligibilityRequest.getPerson())
-                ? createEligibilityResponse(household)
+                ? createEligibleResponse(household)
                 : EligibilityResponse.builder().eligibilityStatus(NOMATCH).build();
     }
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/HMRCIntegrationTests.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/HMRCIntegrationTests.java
@@ -1,7 +1,5 @@
 package uk.gov.dhsc.htbhf.hmrc;
 
-import org.assertj.core.api.AssertionsForClassTypes;
-import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -21,6 +19,7 @@ import uk.gov.dhsc.htbhf.hmrc.repository.HouseholdRepository;
 
 import java.net.URI;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -65,7 +64,8 @@ public class HMRCIntegrationTests {
         given(restTemplateWithIdHeaders.postForEntity(anyString(), any(), eq(EligibilityResponse.class))).willReturn(hmrcEligibilityResponse);
 
         //When
-        ResponseEntity<EligibilityResponse> response = restTemplate.exchange(buildRequestEntity(aValidEligibilityRequest()), EligibilityResponse.class);
+        ResponseEntity<EligibilityResponse> response = callService(aValidEligibilityRequest());
+
         //Then
         assertResponseCorrectWithHouseholdDetails(response, HOUSEHOLD_INDENTIFIER, ELIGIBLE);
         verify(restTemplateWithIdHeaders).postForEntity(HMRC_URL, aValidHMRCEligibilityRequest(), EligibilityResponse.class);
@@ -125,10 +125,10 @@ public class HMRCIntegrationTests {
     }
 
     private void assertResponseCorrect(ResponseEntity<EligibilityResponse> response, EligibilityResponse expectedResponse) {
-        AssertionsForInterfaceTypes.assertThat(response.getStatusCode()).isEqualTo(OK);
+        assertThat(response.getStatusCode()).isEqualTo(OK);
         EligibilityResponse eligibilityResponse = response.getBody();
-        AssertionsForClassTypes.assertThat(eligibilityResponse).isNotNull();
-        AssertionsForClassTypes.assertThat(eligibilityResponse).isEqualTo(expectedResponse);
+        assertThat(eligibilityResponse).isNotNull();
+        assertThat(eligibilityResponse).isEqualTo(expectedResponse);
     }
 
     private RequestEntity buildRequestEntity(Object requestObject) {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/HMRCIntegrationTests.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/HMRCIntegrationTests.java
@@ -1,0 +1,139 @@
+package uk.gov.dhsc.htbhf.hmrc;
+
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.assertj.core.api.AssertionsForInterfaceTypes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.dhsc.htbhf.hmrc.model.EligibilityRequest;
+import uk.gov.dhsc.htbhf.hmrc.model.EligibilityResponse;
+import uk.gov.dhsc.htbhf.hmrc.model.EligibilityStatus;
+import uk.gov.dhsc.htbhf.hmrc.model.PersonDTO;
+import uk.gov.dhsc.htbhf.hmrc.repository.HouseholdRepository;
+
+import java.net.URI;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.springframework.http.HttpStatus.OK;
+import static uk.gov.dhsc.htbhf.hmrc.model.EligibilityStatus.ELIGIBLE;
+import static uk.gov.dhsc.htbhf.hmrc.model.EligibilityStatus.NOMATCH;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.EligibilityRequestTestFactory.aValidEligibilityRequest;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.EligibilityRequestTestFactory.anEligibilityRequestWithPerson;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.EligibilityResponseTestFactory.aValidEligibilityResponseBuilder;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.EligibilityResponseTestFactory.anEligibilityResponse;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HMRCEligibilityRequestTestDataFactory.aValidHMRCEligibilityRequest;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HouseholdTestDataFactory.aHousehold;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HouseholdTestDataFactory.aHouseholdWithChildrenAged6and24months;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.PersonDTOTestFactory.aValidPersonBuilder;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.TestConstants.HOMER_NINO;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.TestConstants.HOUSEHOLD_INDENTIFIER;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class HMRCIntegrationTests {
+
+    private static final URI ENDPOINT = URI.create("/v1/hmrc/eligibility");
+
+    private static final String HMRC_URL = "http://localhost:8130/v1/hmrc/benefits";
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private HouseholdRepository householdRepository;
+
+    @MockBean
+    private RestTemplate restTemplateWithIdHeaders;
+
+    @Test
+    void shouldReturnEligibilityResponseWhenNotInDatabase() {
+        //Given
+        ResponseEntity<EligibilityResponse> hmrcEligibilityResponse = new ResponseEntity<>(anEligibilityResponse(), OK);
+        given(restTemplateWithIdHeaders.postForEntity(anyString(), any(), eq(EligibilityResponse.class))).willReturn(hmrcEligibilityResponse);
+
+        //When
+        ResponseEntity<EligibilityResponse> response = restTemplate.exchange(buildRequestEntity(aValidEligibilityRequest()), EligibilityResponse.class);
+        //Then
+        assertResponseCorrectWithHouseholdDetails(response, HOUSEHOLD_INDENTIFIER, ELIGIBLE);
+        verify(restTemplateWithIdHeaders).postForEntity(HMRC_URL, aValidHMRCEligibilityRequest(), EligibilityResponse.class);
+    }
+
+    @ParameterizedTest(name = "Should return eligible response for claimant [{0}] Simpson stored in UC household table")
+    @CsvSource({"Homer, EB654321B",
+            "Marge, EB876543A"})
+    void shouldReturnEligibleWhenMatchesHouseholdInDatabase(String parentName, String nino) {
+        //Given
+        householdRepository.save(aHouseholdWithChildrenAged6and24months());
+        PersonDTO person = aValidPersonBuilder().firstName(parentName).nino(nino).build();
+        EligibilityRequest eligibilityRequest = anEligibilityRequestWithPerson(person);
+
+        //When
+        ResponseEntity<EligibilityResponse> response = callService(eligibilityRequest);
+
+        //Then
+        assertResponseCorrectWithHouseholdDetails(response, HOUSEHOLD_INDENTIFIER, ELIGIBLE);
+        verifyZeroInteractions(restTemplateWithIdHeaders);
+        householdRepository.deleteAll();
+    }
+
+    @Test
+    void shouldReturnNoMatchWhenMatchesNinoButNotNameInDatabase() {
+        //Given
+        householdRepository.save(aHousehold());
+        PersonDTO person = aValidPersonBuilder().lastName("noMatch").nino(HOMER_NINO).build();
+        EligibilityRequest eligibilityRequest = anEligibilityRequestWithPerson(person);
+
+        //When
+        ResponseEntity<EligibilityResponse> response = callService(eligibilityRequest);
+
+        //Then
+        assertResponseCorrectWithStatusOnly(response, NOMATCH);
+        verifyZeroInteractions(restTemplateWithIdHeaders);
+        householdRepository.deleteAll();
+    }
+
+    private ResponseEntity<EligibilityResponse> callService(EligibilityRequest eligibilityRequest) {
+        return restTemplate.exchange(buildRequestEntity(eligibilityRequest), EligibilityResponse.class);
+    }
+
+    private void assertResponseCorrectWithHouseholdDetails(ResponseEntity<EligibilityResponse> response, String householdIdentifier, EligibilityStatus status) {
+        EligibilityResponse expectedResponse = aValidEligibilityResponseBuilder()
+                .householdIdentifier(householdIdentifier)
+                .eligibilityStatus(status)
+                .build();
+        assertResponseCorrect(response, expectedResponse);
+    }
+
+    private void assertResponseCorrectWithStatusOnly(ResponseEntity<EligibilityResponse> response, EligibilityStatus status) {
+        EligibilityResponse expectedResponse = EligibilityResponse.builder()
+                .eligibilityStatus(status)
+                .build();
+        assertResponseCorrect(response, expectedResponse);
+    }
+
+    private void assertResponseCorrect(ResponseEntity<EligibilityResponse> response, EligibilityResponse expectedResponse) {
+        AssertionsForInterfaceTypes.assertThat(response.getStatusCode()).isEqualTo(OK);
+        EligibilityResponse eligibilityResponse = response.getBody();
+        AssertionsForClassTypes.assertThat(eligibilityResponse).isNotNull();
+        AssertionsForClassTypes.assertThat(eligibilityResponse).isEqualTo(expectedResponse);
+    }
+
+    private RequestEntity buildRequestEntity(Object requestObject) {
+        var headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return new RequestEntity<>(requestObject, headers, HttpMethod.POST, ENDPOINT);
+    }
+}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/factory/EligibilityResponseFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/factory/EligibilityResponseFactoryTest.java
@@ -6,7 +6,7 @@ import uk.gov.dhsc.htbhf.hmrc.model.EligibilityResponse;
 import uk.gov.dhsc.htbhf.hmrc.model.EligibilityStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.dhsc.htbhf.hmrc.factory.EligibilityResponseFactory.createEligibleResponse;
+import static uk.gov.dhsc.htbhf.hmrc.factory.EligibilityResponseFactory.createEligibilityResponse;
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.HouseholdTestDataFactory.aHousehold;
 
 
@@ -16,7 +16,7 @@ public class EligibilityResponseFactoryTest {
     void shouldCreateResponseFromHousehold() {
         Household household = aHousehold();
 
-        EligibilityResponse response = createEligibleResponse(household);
+        EligibilityResponse response = createEligibilityResponse(household, EligibilityStatus.ELIGIBLE);
 
         assertThat(response.getEligibilityStatus()).isEqualTo(EligibilityStatus.ELIGIBLE);
         assertThat(response.getHouseholdIdentifier()).isEqualTo(household.getHouseholdIdentifier());

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/factory/EligibilityResponseFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/factory/EligibilityResponseFactoryTest.java
@@ -3,10 +3,11 @@ package uk.gov.dhsc.htbhf.hmrc.factory;
 import org.junit.jupiter.api.Test;
 import uk.gov.dhsc.htbhf.hmrc.entity.Household;
 import uk.gov.dhsc.htbhf.hmrc.model.EligibilityResponse;
+import uk.gov.dhsc.htbhf.hmrc.model.EligibilityStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.dhsc.htbhf.hmrc.entity.HouseholdFactory.aHousehold;
-import static uk.gov.dhsc.htbhf.hmrc.factory.EligibilityResponseFactory.createEligibilityResponse;
+import static uk.gov.dhsc.htbhf.hmrc.factory.EligibilityResponseFactory.createEligibleResponse;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HouseholdTestDataFactory.aHousehold;
 
 
 public class EligibilityResponseFactoryTest {
@@ -15,8 +16,9 @@ public class EligibilityResponseFactoryTest {
     void shouldCreateResponseFromHousehold() {
         Household household = aHousehold();
 
-        EligibilityResponse response = createEligibilityResponse(household);
+        EligibilityResponse response = createEligibleResponse(household);
 
+        assertThat(response.getEligibilityStatus()).isEqualTo(EligibilityStatus.ELIGIBLE);
         assertThat(response.getHouseholdIdentifier()).isEqualTo(household.getHouseholdIdentifier());
         assertThat(response.getNumberOfChildrenUnderFour()).isEqualTo(2);
         assertThat(response.getNumberOfChildrenUnderOne()).isEqualTo(1);

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/repository/HouseholdRepositoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/repository/HouseholdRepositoryTest.java
@@ -11,9 +11,9 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.dhsc.htbhf.hmrc.entity.HouseholdFactory.aHousehold;
-import static uk.gov.dhsc.htbhf.hmrc.entity.HouseholdFactory.aHouseholdWithNoAdultsOrChildren;
-import static uk.gov.dhsc.htbhf.hmrc.entity.HouseholdFactory.anAdultWithNino;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HouseholdTestDataFactory.aHousehold;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HouseholdTestDataFactory.aHouseholdWithNoAdultsOrChildren;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HouseholdTestDataFactory.anAdultWithNino;
 
 @DataJpaTest
 public class HouseholdRepositoryTest {

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/service/EligibilityServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/service/EligibilityServiceTest.java
@@ -23,9 +23,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.springframework.http.HttpStatus.OK;
-import static uk.gov.dhsc.htbhf.hmrc.entity.HouseholdFactory.aHousehold;
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.EligibilityResponseTestFactory.anEligibilityResponse;
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.HMRCEligibilityRequestTestDataFactory.aValidHMRCEligibilityRequest;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HouseholdTestDataFactory.aHousehold;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/service/HouseholdVerifierTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/service/HouseholdVerifierTest.java
@@ -5,8 +5,8 @@ import uk.gov.dhsc.htbhf.hmrc.entity.Adult;
 import uk.gov.dhsc.htbhf.hmrc.entity.Household;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static uk.gov.dhsc.htbhf.hmrc.entity.HouseholdFactory.aHouseholdWithNoAdultsOrChildren;
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.HMRCPersonDTOTestDataFactory.aValidHMRCPerson;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.HouseholdTestDataFactory.aHouseholdWithNoAdultsOrChildren;
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.TestConstants.LISA_FORENAME;
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.TestConstants.SIMPSONS_ADDRESS_LINE_1;
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.TestConstants.SIMPSONS_POSTCODE;

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/testhelper/EligibilityResponseTestFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/testhelper/EligibilityResponseTestFactory.java
@@ -3,21 +3,23 @@ package uk.gov.dhsc.htbhf.hmrc.testhelper;
 import uk.gov.dhsc.htbhf.hmrc.model.EligibilityResponse;
 
 import static uk.gov.dhsc.htbhf.hmrc.model.EligibilityStatus.ELIGIBLE;
+import static uk.gov.dhsc.htbhf.hmrc.testhelper.TestConstants.HOUSEHOLD_INDENTIFIER;
 
 public class EligibilityResponseTestFactory {
-
-
-    public static final String HOUSEHOLD_INDENTIFIER = "household1";
 
     public static EligibilityResponse anEligibilityResponse() {
         return aValidEligibilityResponseBuilder().build();
     }
 
+    /**
+     * Returns an eligibility response matching the household from HouseholdTestDataFactory.
+     * @return an eligibility response matching the household from HouseholdTestDataFactory.
+     */
     public static EligibilityResponse.EligibilityResponseBuilder aValidEligibilityResponseBuilder() {
         return EligibilityResponse.builder()
                 .eligibilityStatus(ELIGIBLE)
                 .numberOfChildrenUnderOne(1)
-                .numberOfChildrenUnderFour(1)
+                .numberOfChildrenUnderFour(2)
                 .householdIdentifier(HOUSEHOLD_INDENTIFIER);
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/testhelper/HouseholdTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/testhelper/HouseholdTestDataFactory.java
@@ -1,12 +1,20 @@
-package uk.gov.dhsc.htbhf.hmrc.entity;
+package uk.gov.dhsc.htbhf.hmrc.testhelper;
+
+import uk.gov.dhsc.htbhf.hmrc.entity.Adult;
+import uk.gov.dhsc.htbhf.hmrc.entity.Child;
+import uk.gov.dhsc.htbhf.hmrc.entity.Household;
 
 import java.time.LocalDate;
 
 import static uk.gov.dhsc.htbhf.hmrc.testhelper.TestConstants.*;
 
-public class HouseholdFactory {
+public class HouseholdTestDataFactory {
 
     public static Household aHousehold() {
+        return aHouseholdWithChildrenAged6and24months();
+    }
+
+    public static Household aHouseholdWithChildrenAged6and24months() {
         return aHouseholdWithNoAdultsOrChildren()
                 .build()
                 .addAdult(anAdult(HOMER_FORENAME, SIMPSONS_SURNAME, HOMER_NINO))
@@ -19,7 +27,7 @@ public class HouseholdFactory {
     public static Household.HouseholdBuilder aHouseholdWithNoAdultsOrChildren() {
         return Household.builder()
                 .fileImportNumber(1)
-                .householdIdentifier("aHouseholdIdentifier")
+                .householdIdentifier(HOUSEHOLD_INDENTIFIER)
                 .build()
                 .toBuilder();
     }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/testhelper/TestConstants.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/hmrc/testhelper/TestConstants.java
@@ -5,10 +5,11 @@ import java.time.LocalDate;
 
 public class TestConstants {
 
+    public static final String HOUSEHOLD_INDENTIFIER = "household1";
     public static final String SIMPSONS_SURNAME = "Simpson";
-    public static  final String SIMPSONS_ADDRESS_LINE_1 = "742 Evergreen Terrace";
-    public static  final String SIMPSONS_ADDRESS_LINE_2 = "Mystery Spot";
-    public static  final String SIMPSONS_TOWN_OR_CITY = "Springfield";
+    public static final String SIMPSONS_ADDRESS_LINE_1 = "742 Evergreen Terrace";
+    public static final String SIMPSONS_ADDRESS_LINE_2 = "Mystery Spot";
+    public static final String SIMPSONS_TOWN_OR_CITY = "Springfield";
     public static final String SIMPSONS_POSTCODE = "AA11AA";
 
     public static final LocalDate LISA_DOB = LocalDate.parse("1985-12-31");

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -16,4 +16,4 @@ spring:
 ###
 
 hmrc:
-  base-uri: http://localhost:8080
+  base-uri: http://localhost:8130

--- a/swagger.yml
+++ b/swagger.yml
@@ -11,7 +11,7 @@ info:
   license:
     name: "MIT"
     url: "https://opensource.org/licenses/MIT"
-host: "localhost:49330"
+host: "N/A"
 basePath: "/"
 tags:
 - name: "hmrc-eligibility-controller"

--- a/swagger.yml
+++ b/swagger.yml
@@ -11,7 +11,7 @@ info:
   license:
     name: "MIT"
     url: "https://opensource.org/licenses/MIT"
-host: "localhost:56583"
+host: "localhost:49330"
 basePath: "/"
 tags:
 - name: "hmrc-eligibility-controller"


### PR DESCRIPTION
- ~Rename `createEligibilityResponse` to `createEligibleResponse` as it will always return a response with a status of ELIGIBLE~
- Add missing eligibility status
- Write unit test for missing eligibility status bug
- Refactor test constants for integration test matching
- Write integration test for missing eligibility status bug