### PR TITLE
HTBHF-2195 removed logging of household id

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/service/EligibilityService.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/hmrc/service/EligibilityService.java
@@ -32,7 +32,7 @@ public class EligibilityService {
     public EligibilityResponse checkEligibility(HMRCEligibilityRequest eligibilityRequest) {
         Optional<Household> household = repository.findHouseholdByAdultWithNino(eligibilityRequest.getPerson().getNino());
         if (household.isPresent()) {
-            log.debug("Matched CTC household: {}", household.get().getHouseholdIdentifier());
+            log.debug("Matched CTC household: {}", household.get().getId());
             return getEligibilityResponse(eligibilityRequest, household.get());
         }
 


### PR DESCRIPTION
Due to the manual insertion of data, household identifier includes personally identifiable information.